### PR TITLE
Adds an API endpoint for users to leave a team by removing their membership.

### DIFF
--- a/src/main/java/com/example/group2backend/controller/TeamController.java
+++ b/src/main/java/com/example/group2backend/controller/TeamController.java
@@ -87,4 +87,15 @@ public class TeamController {
         List<TeamWithMembers> teams = manageService.getAllTeams(user.getId(), null);
         return ResponseEntity.ok(teams);
     }
+    @Operation(summary = "Leave a team")
+    @PostMapping("/leave")
+    public ResponseEntity<String> leaveTeam(@RequestBody Team team, Authentication auth) {
+        Long userId = userService.getUserByUsername(auth.getName()).getId();
+        team = teamService.getTeam(team.getId());   
+
+        manageService.removeTeamMembers(team, userId); 
+        teamService.updateTeam(team);                   
+
+        return ResponseEntity.ok("Left the team");
+    }
 }


### PR DESCRIPTION
This PR adds a new API endpoint in TeamController to allow users to leave a team.

- Added POST /leave endpoint
- Removes user from team members
- Updates team info accordingly

Tested locally and verified functionality.
